### PR TITLE
Calling recyclable (for drivers) inside recycler, with less boilerplate

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,11 +1,11 @@
 import Cycle from '@cycle/xstream-run';
 import {makeDOMDriver} from '@cycle/dom';
-import {recycler, recyclable} from '../src/recycle';
+import {recycler} from '../src/recycle';
 
 var app = require('./counter').default;
 
 const drivers = () => ({
-  DOM: recyclable(makeDOMDriver('.app'))
+  DOM: makeDOMDriver('.app')
 });
 
 const recycle = recycler(Cycle, app, drivers);

--- a/src/recycle.js
+++ b/src/recycle.js
@@ -25,7 +25,19 @@ const SourceType = either({
   'undefined': (val) => typeof val === 'undefined'
 });
 
+function wrapDrivers (driversFactory) {
+  return () => {
+    let drivers = driversFactory();
+    Object.keys(drivers).forEach(function (key) {
+      drivers[key] = recyclable(drivers[key]);
+    });
+    return drivers;
+  };
+}
+
 export function recycler (Cycle, app, driversFactory) {
+  driversFactory = wrapDrivers(driversFactory);
+
   let drivers = driversFactory();
   let {sinks, sources, run} = Cycle(app, drivers);
 
@@ -33,7 +45,7 @@ export function recycler (Cycle, app, driversFactory) {
 
   return (app) => {
     let newDrivers = driversFactory();
-    let newSinksSourceDispose = recycle(app, driversFactory(), drivers, {sources, sinks, dispose});
+    let newSinksSourceDispose = recycle(app, newDrivers, drivers, {sources, sinks, dispose});
 
     sinks = newSinksSourceDispose.sinks;
     sources = newSinksSourceDispose.sources;

--- a/test/recycle-test.js
+++ b/test/recycle-test.js
@@ -1,5 +1,5 @@
 /* globals describe, it */
-import {recycle, recyclable} from '../src/recycle';
+import {recycle} from '../src/recycle';
 import assert from 'assert';
 import fromDiagram from 'xstream/extra/fromDiagram';
 import Cycle from '@cycle/xstream-run';
@@ -91,7 +91,7 @@ describe('recycle', () => {
     };
 
     const driversFn = () => ({
-      click$: recyclable(() => streams.clickInput)
+      click$: () => streams.clickInput
     });
 
     let drivers = driversFn();
@@ -129,7 +129,7 @@ describe('recycle', () => {
     };
 
     const driversFn = () => ({
-      click$: recyclable(() => ({times: (multiplier) => streams.clickInput.map(i => i * multiplier)}))
+      click$: () => ({times: (multiplier) => streams.clickInput.map(i => i * multiplier)})
     });
 
     const drivers = driversFn();


### PR DESCRIPTION
Okay, as we discussed earlier, this is an example about a way to reduce the boilerplate for recycle.

This has clearly the downside of preventing the user to choose what drivers should be replayed, and what should not, what could affects the behavior of the app, if it uses some effectful driver (time driver, e.g.).

Maybe we could find a half term between the two approaches.